### PR TITLE
updaterハッシュのデーターベース登録を実装

### DIFF
--- a/app/Controller/admin/update.php
+++ b/app/Controller/admin/update.php
@@ -154,7 +154,6 @@ function setUpdate($input,$db){
 		$info_assets = null;
 		foreach ($assets_info as $assets){
 			if($assets["name"] == $info["keyword"]."-".$info["version"]."_info.json"){
-				echo("ok");
 				$info_assets = $assets;
 				break;
 			}
@@ -193,8 +192,7 @@ function setUpdate($input,$db){
 		$ret = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/assets/".$info_assets["id"], "DELETE");
 
 		//検証とドラフトのリリース
-		$gitData=GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"],"PATCH",array("draft"=>false));
-
+		$gitData=GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"],"PATCH",array("draft"=>false, "body" => $versionData["hist_text"]));
 		$updaterequests->delete(array("id"=>$request["id"]));
 		return "更新が完了しました。";
 	}

--- a/app/Controller/admin/update.php
+++ b/app/Controller/admin/update.php
@@ -151,11 +151,16 @@ function setUpdate($input,$db){
 		$softwares=new Softwares($db);
 		$soft=$softwares->select(array("keyword"=>$info["keyword"]));
 		$assets_info = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"]."/assets");
-		foreach $assets_info as $assets{
-			if $assets["name"] == $info["keyword"]."-".$info["version"]."_info.json"{
+		$info_assets = null;
+		foreach ($assets_info as $assets){
+			if($assets["name"] == $info["keyword"]."-".$info["version"]."_info.json"){
+				echo("ok");
 				$info_assets = $assets;
 				break;
 			}
+		}
+		if ($info_assets == null){
+			throw new Exception("updater hash notfound.");
 		}
 		$content = GitHubUtil::get_assets($info_assets["url"]);
 		$file_info = json_decode($content, true);
@@ -169,7 +174,7 @@ function setUpdate($input,$db){
 			"hist_text"=>$info["detailString"],
 			"package_URL"=>"https://github.com/".$soft["gitHubURL"]."releases/download/".$info["version"]."/".$info["file"],
 			"updater_URL"=>"https://github.com/".$soft["gitHubURL"]."releases/download/".$info["version"]."/".$info["patch"],
-			"updater_hash": $file_info["patch_hash"],
+			"updater_hash" => $file_info["patch_hash"],
 			"update_min_Major"=>0,
 			"update_min_minor"=>0,
 			"released_at"=>date("Y-m-d"),
@@ -185,7 +190,7 @@ function setUpdate($input,$db){
 			"url"=>"/software/".$info["keyword"],
 			0
 		)));
-		$ret = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/assets/".$info_assets["id"], "DELETE")
+		$ret = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/assets/".$info_assets["id"], "DELETE");
 
 		//検証とドラフトのリリース
 		$gitData=GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"],"PATCH",array("draft"=>false));

--- a/app/Controller/admin/update.php
+++ b/app/Controller/admin/update.php
@@ -150,7 +150,15 @@ function setUpdate($input,$db){
 		//ソフトIDをとってくる
 		$softwares=new Softwares($db);
 		$soft=$softwares->select(array("keyword"=>$info["keyword"]));
-
+		$assets_info = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"]."/assets");
+		foreach $assets_info as $assets{
+			if $assets["name"] == $info["keyword"]."-".$info["version"]."_info.json"{
+				$info_assets = $assets;
+				break;
+			}
+		}
+		$content = GitHubUtil::get_assets($info_assets["url"]);
+		$file_info = json_decode($content, true);
 		$versionData=array(
 			"software_id"=>$soft["id"],
 
@@ -161,6 +169,7 @@ function setUpdate($input,$db){
 			"hist_text"=>$info["detailString"],
 			"package_URL"=>"https://github.com/".$soft["gitHubURL"]."releases/download/".$info["version"]."/".$info["file"],
 			"updater_URL"=>"https://github.com/".$soft["gitHubURL"]."releases/download/".$info["version"]."/".$info["patch"],
+			"updater_hash": $file_info["patch_hash"],
 			"update_min_Major"=>0,
 			"update_min_minor"=>0,
 			"released_at"=>date("Y-m-d"),
@@ -176,6 +185,7 @@ function setUpdate($input,$db){
 			"url"=>"/software/".$info["keyword"],
 			0
 		)));
+		$ret = GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/assets/".$info_assets["id"], "DELETE")
 
 		//検証とドラフトのリリース
 		$gitData=GitHubUtil::connect("/repos/".$soft["gitHubURL"]."releases/".$info["releaseId"],"PATCH",array("draft"=>false));

--- a/app/Controller/api/checkUpdate.php
+++ b/app/Controller/api/checkUpdate.php
@@ -30,7 +30,6 @@ $app->get('/api/checkUpdate', function (Request $request, Response $response) {
 		return $response->withJson($json);
 	}
 	$software=$software[0];
-	var_dump($software);
 	SoftwareUtil::makeTextVersion($software);
 	$ret=SoftwareUtil::conpareVersion($software["versionText"],$data["version"]);
 

--- a/app/Controller/api/checkUpdate.php
+++ b/app/Controller/api/checkUpdate.php
@@ -30,6 +30,7 @@ $app->get('/api/checkUpdate', function (Request $request, Response $response) {
 		return $response->withJson($json);
 	}
 	$software=$software[0];
+	var_dump($software);
 	SoftwareUtil::makeTextVersion($software);
 	$ret=SoftwareUtil::conpareVersion($software["versionText"],$data["version"]);
 
@@ -43,6 +44,7 @@ $app->get('/api/checkUpdate', function (Request $request, Response $response) {
 		$json["updater_url"] = $software["updater_URL"];
 		$json["update_version"] = $software["versionText"];
 		$json["update_description"] = $software["hist_text"];
+		$json["updater_hash"] = $software["updater_hash"];
 		return $response->withJson($json,200,JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
 	}
 

--- a/app/Util/GitHubUtil.php
+++ b/app/Util/GitHubUtil.php
@@ -39,4 +39,22 @@ class GitHubUtil{
 		return json_decode($result,true);
 	}
 
+	static function get_assets($assets_url){
+		$header=array(
+			"Accept: application/octet-stream",
+			"User-Agent: ACTLaboratory-webadmin",
+			"Authorization: token ".getenv("GITHUB_TOKEN")
+		);
+		
+		$context = array(
+			"http" => array(
+				"method"  => "GET",
+				"header"  => implode("\r\n", $header),
+				"ignore_errors"=>true
+				)
+		);
+		$content = file_get_contents($assets_url, false, stream_context_create($context));
+		return $content;
+	}
+
 }

--- a/app/Util/GitHubUtil.php
+++ b/app/Util/GitHubUtil.php
@@ -42,18 +42,15 @@ class GitHubUtil{
 	static function get_assets($assets_url){
 		$header=array(
 			"Accept: application/octet-stream",
-			"User-Agent: ACTLaboratory-webadmin",
-			"Authorization: token ".getenv("GITHUB_TOKEN")
+			"Authorization: token ".getenv("GITHUB_TOKEN"),
 		);
-		
-		$context = array(
-			"http" => array(
-				"method"  => "GET",
-				"header"  => implode("\r\n", $header),
-				"ignore_errors"=>true
-				)
-		);
-		$content = file_get_contents($assets_url, false, stream_context_create($context));
+		$handle = curl_init($assets_url);
+		curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($handle, CURLOPT_USERAGENT, "ACTLaboratory-webadmin");
+		curl_setopt($handle, CURLOPT_HTTPHEADER, $header);
+		curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
+		$content = curl_exec($handle);
+		curl_close($handle);
 		return $content;
 	}
 

--- a/setup.sql
+++ b/setup.sql
@@ -57,6 +57,7 @@ CREATE TABLE software_versions(
 	hist_text text NOT NULL,
 	package_URL char(255),
 	updater_URL char(255),
+	updater_hash char(32),
 	update_min_Major TINYINT,
 	update_min_minor TINYINT,
 


### PR DESCRIPTION
updater_hashカラムをDBに追加しrelease時にassetsからupdaterのハッシュを取得してデーターベース登録までを実装しました。テスト、確認お願いします。