### PR TITLE
ソフトウェアタイトルの長さ上限を増加

### DIFF
--- a/app/Controller/admin/edit.php
+++ b/app/Controller/admin/edit.php
@@ -174,9 +174,9 @@ function paramCheck($input){
 		$message.="不正なリクエストです。最初からやり直してください。";
 	}
 	if (ValidationUtil::checkParam($input,array(
-		"title"=>"/^.{3,30}$/u"
+		"title"=>"/^.{3,35}$/u"
 	))==false){
-		$message.="タイトルは3文字以上30文字以内で入力してください。";
+		$message.="タイトルは3文字以上35文字以内で入力してください。";
 	}
 	if (ValidationUtil::checkParam($input,array(
 		"keyword"=>"/^[A-Z]{3,10}$/"


### PR DESCRIPTION
ソフト尾ウェアタイトルの長さ上限を30文字から35文字に変更